### PR TITLE
Fix thesaurus indexing with mutli-database

### DIFF
--- a/lib/Alchemy/Phrasea/Controller/Thesaurus/Thesaurus.php
+++ b/lib/Alchemy/Phrasea/Controller/Thesaurus/Thesaurus.php
@@ -134,7 +134,7 @@ class Thesaurus implements ControllerProviderInterface
         if ($request->get("typ") == "TH" || $request->get("typ") == "CT") {
             try {
                 $databox = $app['phraseanet.appbox']->get_databox((int) $bid);
-                $databox->get_connection();
+                $connbas = $databox->get_connection();
 
                 if ($request->get("typ") == "TH") {
                     $domth = $databox->get_dom_thesaurus();

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/TermIndexer.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Indexer/TermIndexer.php
@@ -42,6 +42,7 @@ class TermIndexer
         foreach ($this->appbox->get_databoxes() as $databox) {
             /** @var databox $databox */
             $databoxId              = $databox->get_sbas_id();
+
             $document               = self::thesaurusFromDatabox($databox);
             $dedicatedFieldTerms    = $this->getDedicatedFieldTerms($databox, $document);
 
@@ -50,7 +51,9 @@ class TermIndexer
                 // Term structure
                 $id = $term['id'];
                 unset($term['id']);
+
                 $term['databox_id'] = $databoxId;
+                $term['branch_id'] = $id;
 
                 // @todo move to the TermVisitor? dunno.
                 $term['fields'] = null;
@@ -64,9 +67,10 @@ class TermIndexer
 
                 // Index request
                 $params = array();
-                $params['id'] = $id;
+                $params['id'] = sprintf('%s_%s', $databoxId, $id);
                 $params['type'] = self::TYPE_NAME;
                 $params['body'] = $term;
+
                 $bulk->index($params);
             });
 
@@ -113,6 +117,7 @@ class TermIndexer
             ->add('context', 'string')->addAnalyzedVersion($this->locales)
             ->add('path', 'string')->notAnalyzed()
             ->add('lang', 'string')->notAnalyzed()
+            ->add('branch_id', 'string')->notAnalyzed()
             ->add('databox_id', 'integer')
             ->add('fields', 'string')->notAnalyzed()
         ;


### PR DESCRIPTION
Given the following thesaurus

```yaml
discipline ; enseignement
	yoga ; yogi ; gym
		kundalini ; mantra
		bikram
		hatha
```

If you replicate this thesaurus over n database, it will not index every entries because of id collision