### PR TITLE
Search by thesaurus term (with optional context)

### DIFF
--- a/grammar/query.pp
+++ b/grammar/query.pp
@@ -40,7 +40,10 @@ bracketed_text:
     ::bracket_:: text() ::_bracket::
 
 text:
-    ( word() | keyword() | symbol() )+
+    ( word() | keyword() | symbol() )+ context()?
+
+#context:
+    ::parenthese_:: ( word() )+ ::_parenthese::
 
 word:
     <word> | string()

--- a/grammar/query.pp
+++ b/grammar/query.pp
@@ -1,7 +1,9 @@
 %skip   space           \s
 
-%token  bracket_        \(
-%token _bracket         \)
+%token  parenthese_     \(
+%token _parenthese      \)
+%token  bracket_        \[
+%token _bracket         \]
 %token  quote_          "        -> string
 %token  string:string   [^"]+
 %token  string:_quote   "        -> default
@@ -9,7 +11,7 @@
 %token  and             AND
 %token  or              OR
 %token  except          EXCEPT
-%token  word            [^\s\(\)]+
+%token  word            [^\s\(\)\[\]]+
 
 // relative order of precedence is NOT > XOR > AND > OR
 
@@ -26,12 +28,18 @@ ternary:
     quaternary() ( ::and:: #and primary() )?
 
 quaternary:
-    term() ( ::in:: #in word() )?
+    ( group() | term() ) ( ::in:: #in word() )?
+
+group:
+    ( ::parenthese_:: #group primary() ::_parenthese:: )
 
 term:
-    ( ::bracket_:: primary() ::_bracket:: ) | text()
+    ( bracketed_text() #thesaurus_term ) | ( text() #text )
 
-#text:
+bracketed_text:
+    ::bracket_:: text() ::_bracket::
+
+text:
     ( word() | keyword() | symbol() )+
 
 word:
@@ -44,4 +52,4 @@ keyword:
     <in> | <except> | <and> | <or>
 
 symbol:
-    ::bracket_:: | ::_bracket::
+    ::parenthese_:: | ::_parenthese:: | ::bracket_:: | ::_bracket::

--- a/lib/Alchemy/Phrasea/Command/SearchEngine/Debug/QueryParseCommand.php
+++ b/lib/Alchemy/Phrasea/Command/SearchEngine/Debug/QueryParseCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Stopwatch\Stopwatch;
 
 class QueryParseCommand extends Command
 {
@@ -64,6 +65,10 @@ class QueryParseCommand extends Command
         $postprocessing = !$input->getOption('no-compiler-postprocessing');
 
         $parser = $this->container['query_parser'];
+
+        $stopwatch = new Stopwatch();
+        $stopwatch->start('parsing');
+
         if ($input->getOption('compiler-dump')) {
             $dump = $parser->dump($string, $postprocessing);
         } else {
@@ -71,8 +76,12 @@ class QueryParseCommand extends Command
             $dump = $query->dump();
         }
 
+        $event = $stopwatch->stop('parsing');
+
         if (!$raw) {
             $output->writeln($dump);
+            $output->writeln(str_repeat('-', 20));
+            $output->writeln(sprintf("Took %sms", $event->getDuration()));
         } else {
             $output->write($dump);
         }

--- a/lib/Alchemy/Phrasea/Core/Provider/SearchEngineServiceProvider.php
+++ b/lib/Alchemy/Phrasea/Core/Provider/SearchEngineServiceProvider.php
@@ -174,7 +174,7 @@ class SearchEngineServiceProvider implements ServiceProviderInterface
             $grammarPath = $app['query_parser.grammar_path'];
             $parser = Llk::load(new Read($grammarPath));
 
-            return new QueryParser($parser);
+            return new QueryParser($parser, $app['thesaurus']);
         });
     }
 

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/AbstractTermNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/AbstractTermNode.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Alchemy\Phrasea\SearchEngine\Elastic\AST;
+
+use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContext;
+use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\Concept;
+use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\TermInterface;
+
+abstract class AbstractTermNode extends Node implements TermInterface
+{
+    protected $text;
+    protected $context;
+    private $concepts = array();
+
+    public function __construct($text, Context $context = null)
+    {
+        $this->text = $text;
+        $this->context = $context;
+    }
+
+    public function setConcepts(array $concepts)
+    {
+        $this->concepts = $concepts;
+    }
+
+    protected function buildConceptQueries(QueryContext $context)
+    {
+        $queries = array();
+        foreach (Concept::pruneNarrowConcepts($this->concepts) as $concept) {
+            $queries[]['term']['concept_paths'] = $concept->getPath();
+        }
+
+        return $queries;
+    }
+
+    public function getValue()
+    {
+        return $this->text;
+    }
+
+    public function hasContext()
+    {
+        return $this->context !== null;
+    }
+
+    public function getContext()
+    {
+        return $this->context->getValue();
+    }
+}

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/AbstractTermNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/AbstractTermNode.php
@@ -47,4 +47,9 @@ abstract class AbstractTermNode extends Node implements TermInterface
     {
         return $this->context->getValue();
     }
+
+    public function getTermNodes()
+    {
+        return array($this);
+    }
 }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/BinaryOperator.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/BinaryOperator.php
@@ -19,11 +19,11 @@ abstract class BinaryOperator extends Node
         return sprintf('(%s %s %s)', $this->left, $this->operator, $this->right);
     }
 
-    public function getTextNodes()
+    public function getTermNodes()
     {
         return array_merge(
-            $this->left->getTextNodes(),
-            $this->right->getTextNodes()
+            $this->left->getTermNodes(),
+            $this->right->getTermNodes()
         );
     }
 }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/Context.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/Context.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Alchemy\Phrasea\SearchEngine\Elastic\AST;
+
+use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContext;
+
+class Context
+{
+    private $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+}

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/FieldNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/FieldNode.php
@@ -23,7 +23,7 @@ class FieldNode extends Node
         throw new \LogicException("A keyword can't be converted to a query.");
     }
 
-    public function getTextNodes()
+    public function getTermNodes()
     {
         throw new \LogicException("A keyword can't contain text nodes.");
     }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/InExpression.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/InExpression.php
@@ -22,9 +22,9 @@ class InExpression extends Node
         return $this->expression->buildQuery($context->narrowToFields($fields));
     }
 
-    public function getTextNodes()
+    public function getTermNodes()
     {
-        return $this->expression->getTextNodes();
+        return $this->expression->getTermNodes();
     }
 
     public function __toString()

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/Node.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/Node.php
@@ -11,5 +11,5 @@ abstract class Node
      */
     abstract public function buildQuery(QueryContext $context);
 
-    abstract public function getTextNodes();
+    abstract public function getTermNodes();
 }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/NullQueryNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/NullQueryNode.php
@@ -11,7 +11,7 @@ class NullQueryNode extends Node
         return array('match_all' => array());
     }
 
-    public function getTextNodes()
+    public function getTermNodes()
     {
         return array();
     }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/QuotedTextNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/QuotedTextNode.php
@@ -4,8 +4,15 @@ namespace Alchemy\Phrasea\SearchEngine\Elastic\AST;
 
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContext;
 
-class QuotedTextNode extends TextNode
+class QuotedTextNode extends Node
 {
+    private $text;
+
+    public function __construct($text)
+    {
+        $this->text = $text;
+    }
+
     public function buildQuery(QueryContext $context)
     {
         return array(
@@ -16,6 +23,11 @@ class QuotedTextNode extends TextNode
                 // 'operator'  => 'and'
             )
         );
+    }
+
+    public function getTermNodes()
+    {
+        return array();
     }
 
     public function __toString()

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/QuotedTextNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/QuotedTextNode.php
@@ -17,4 +17,9 @@ class QuotedTextNode extends TextNode
             )
         );
     }
+
+    public function __toString()
+    {
+        return sprintf('<exact_text:"%s">', $this->text);
+    }
 }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TermNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TermNode.php
@@ -2,16 +2,16 @@
 
 namespace Alchemy\Phrasea\SearchEngine\Elastic\AST;
 
+use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContext;
+
 class TermNode extends TextNode
 {
-    public function getQuery()
+    public function buildQuery(QueryContext $context)
     {
-        throw new \Exception('Corresponding concepts where not linked.');
-    }
+        $query = array();
+        $query['bool']['should'] = $this->buildConceptQueries();
 
-    public function setConcepts(array $concepts)
-    {
-        // TODO
+        return $query;
     }
 
     public function __toString()

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TermNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TermNode.php
@@ -3,6 +3,7 @@
 namespace Alchemy\Phrasea\SearchEngine\Elastic\AST;
 
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContext;
+use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\Term;
 
 class TermNode extends AbstractTermNode
 {
@@ -16,6 +17,6 @@ class TermNode extends AbstractTermNode
 
     public function __toString()
     {
-        return sprintf('<term:%s>', $this->text);
+        return sprintf('<term:%s>', Term::dump($this));
     }
 }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TermNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TermNode.php
@@ -9,7 +9,7 @@ class TermNode extends TextNode
     public function buildQuery(QueryContext $context)
     {
         $query = array();
-        $query['bool']['should'] = $this->buildConceptQueries();
+        $query['bool']['should'] = $this->buildConceptQueries($context);
 
         return $query;
     }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TermNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TermNode.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Alchemy\Phrasea\SearchEngine\Elastic\AST;
+
+class TermNode extends TextNode
+{
+    public function getQuery()
+    {
+        throw new \Exception('Corresponding concepts where not linked.');
+    }
+
+    public function setConcepts(array $concepts)
+    {
+        // TODO
+    }
+
+    public function __toString()
+    {
+        return sprintf('<term:%s>', $this->text);
+    }
+}

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TermNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TermNode.php
@@ -4,7 +4,7 @@ namespace Alchemy\Phrasea\SearchEngine\Elastic\AST;
 
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContext;
 
-class TermNode extends TextNode
+class TermNode extends AbstractTermNode
 {
     public function buildQuery(QueryContext $context)
     {

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TextNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TextNode.php
@@ -30,16 +30,24 @@ class TextNode extends Node implements TermInterface
             )
         );
 
-        if ($this->concepts) {
-            $shoulds = array($query);
-            foreach (Concept::pruneNarrowConcepts($this->concepts) as $concept) {
-                $shoulds[]['term']['concept_paths'] = $concept->getPath();
-            }
+        if ($conceptQueries = $this->buildConceptQueries()) {
+            $textQuery = $query;
             $query = array();
-            $query['bool']['should'] = $shoulds;
+            $query['bool']['should'] = $conceptQueries;
+            $query['bool']['should'][] = $textQuery;
         }
 
         return $query;
+    }
+
+    protected function buildConceptQueries()
+    {
+        $queries = array();
+        foreach (Concept::pruneNarrowConcepts($this->concepts) as $concept) {
+            $queries[]['term']['concept_paths'] = $concept->getPath();
+        }
+
+        return $queries;
     }
 
     public function getTextNodes()

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TextNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TextNode.php
@@ -3,24 +3,11 @@
 namespace Alchemy\Phrasea\SearchEngine\Elastic\AST;
 
 use Alchemy\Phrasea\SearchEngine\Elastic\Search\QueryContext;
-use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\Concept;
+use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\Term;
 use Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus\TermInterface;
 
-class TextNode extends Node implements TermInterface
+class TextNode extends AbstractTermNode
 {
-    protected $text;
-    protected $concepts = array();
-
-    public function __construct($text)
-    {
-        $this->text = $text;
-    }
-
-    public function setConcepts(array $concepts)
-    {
-        $this->concepts = $concepts;
-    }
-
     public function buildQuery(QueryContext $context)
     {
         $query = array(
@@ -30,7 +17,7 @@ class TextNode extends Node implements TermInterface
             )
         );
 
-        if ($conceptQueries = $this->buildConceptQueries()) {
+        if ($conceptQueries = $this->buildConceptQueries($context)) {
             $textQuery = $query;
             $query = array();
             $query['bool']['should'] = $conceptQueries;
@@ -40,16 +27,6 @@ class TextNode extends Node implements TermInterface
         return $query;
     }
 
-    protected function buildConceptQueries()
-    {
-        $queries = array();
-        foreach (Concept::pruneNarrowConcepts($this->concepts) as $concept) {
-            $queries[]['term']['concept_paths'] = $concept->getPath();
-        }
-
-        return $queries;
-    }
-
     public function getTextNodes()
     {
         return array($this);
@@ -57,25 +34,6 @@ class TextNode extends Node implements TermInterface
 
     public function __toString()
     {
-        return sprintf('<text:"%s">', $this->text);
-    }
-
-
-    // Implementation of TermInterface
-
-    public function getValue()
-    {
-        return $this->text;
-    }
-
-    public function hasContext()
-    {
-        return false;
-    }
-
-    public function getContext()
-    {
-        // TODO Insert context during parsing
-        return null;
+        return sprintf('<text:%s>', Term::dump($this));
     }
 }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TextNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TextNode.php
@@ -27,11 +27,6 @@ class TextNode extends AbstractTermNode
         return $query;
     }
 
-    public function getTextNodes()
-    {
-        return array($this);
-    }
-
     public function __toString()
     {
         return sprintf('<text:%s>', Term::dump($this));

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TextNode.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/AST/TextNode.php
@@ -49,7 +49,7 @@ class TextNode extends Node implements TermInterface
 
     public function __toString()
     {
-        return sprintf('"%s"', $this->text);
+        return sprintf('<text:"%s">', $this->text);
     }
 
 

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
@@ -274,11 +274,11 @@ class ElasticSearchEngine implements SearchEngineInterface
 
 
         $thesaurus = $this->app['thesaurus'];
-        $textNodes = $searchQuery->getTextNodes();
-        $concepts = $thesaurus->findConceptsBulk($textNodes);
+        $termNodes = $searchQuery->getTermNodes();
+        $concepts = $thesaurus->findConceptsBulk($termNodes);
 
         foreach ($concepts as $index => $termConcepts) {
-            $node = $textNodes[$index];
+            $node = $termNodes[$index];
             $node->setConcepts($termConcepts);
             $term = Term::dump($node);
             $query['_thesaurus_concepts'][$term] = Concept::toPathArray($termConcepts);

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/ElasticSearchEngine.php
@@ -287,7 +287,7 @@ class ElasticSearchEngine implements SearchEngineInterface
         $recordHelper = $this->app['elasticsearch.record_helper'];
         // TODO Pass options to getFields to include/exclude private fields
         $searchableFields = $recordHelper->getFields();
-        $queryContext = new QueryContext($searchableFields, $this->locales, $this->app['locale']);
+        $queryContext = new QueryContext($this->locales, $this->app['locale'], $searchableFields);
         $recordQuery = $searchQuery->build($queryContext);
 
 

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/NodeTypes.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/NodeTypes.php
@@ -6,11 +6,13 @@ class NodeTypes
 {
     // Tree node types
     const QUERY         = '#query';
+    const GROUP         = '#group';
     const IN_EXPR       = '#in';
     const AND_EXPR      = '#and';
     const OR_EXPR       = '#or';
     const EXCEPT_EXPR   = '#except';
     const FIELD         = '#field';
+    const TERM          = '#thesaurus_term';
     const TEXT          = '#text';
     // Token types for leaf nodes
     const TOKEN_WORD    = 'word';

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/NodeTypes.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/NodeTypes.php
@@ -14,6 +14,7 @@ class NodeTypes
     const FIELD         = '#field';
     const TERM          = '#thesaurus_term';
     const TEXT          = '#text';
+    const CONTEXT       = '#context';
     // Token types for leaf nodes
     const TOKEN_WORD    = 'word';
     const TOKEN_STRING  = 'string';

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/Query.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/Query.php
@@ -18,9 +18,9 @@ class Query
         $this->root = $root;
     }
 
-    public function getTextNodes()
+    public function getTermNodes()
     {
-        return $this->root->getTextNodes();
+        return $this->root->getTermNodes();
     }
 
     public function build(QueryContext $context)

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryVisitor.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryVisitor.php
@@ -121,7 +121,7 @@ class QueryVisitor implements Visit
         foreach ($element->getChildren() as $child) {
             $node = $child->accept($this);
             if ($node instanceof AST\TextNode) {
-                $words[] = $node->getText();
+                $words[] = $node->getValue();
             } else {
                 throw new \Exception('Term node can only contain text nodes');
             }

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryVisitor.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryVisitor.php
@@ -167,11 +167,9 @@ class QueryVisitor implements Visit
                 $root = new AST\TextNode($root->getValue(), $node);
                 continue;
             }
-            // Merge text nodes together, but not with quoted ones
+            // Merge text nodes together (quoted nodes do not)
             if ($root instanceof AST\TextNode &&
-                $node instanceof AST\TextNode &&
-                !$root instanceof AST\QuotedTextNode &&
-                !$node instanceof AST\QuotedTextNode) {
+                $node instanceof AST\TextNode) {
                 // Prevent merge once a context is set
                 if ($root->hasContext()) {
                     throw new \Exception('Unexpected text node after context');

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryVisitor.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Search/QueryVisitor.php
@@ -38,6 +38,9 @@ class QueryVisitor implements Visit
             case NodeTypes::QUERY:
                 return $this->visitQuery($element);
 
+            case NodeTypes::GROUP:
+                return $this->visitNode($element->getChild(0));
+
             case NodeTypes::IN_EXPR:
                 return $this->visitInNode($element);
 
@@ -49,6 +52,9 @@ class QueryVisitor implements Visit
 
             case NodeTypes::EXCEPT_EXPR:
                 return $this->visitExceptNode($element);
+
+            case NodeTypes::TERM:
+                return $this->visitTerm($element);
 
             case NodeTypes::TEXT:
                 return $this->visitText($element);
@@ -107,6 +113,21 @@ class QueryVisitor implements Visit
         $right = $element->getChild(1)->accept($this);
 
         return $factory($left, $right);
+    }
+
+    private function visitTerm(Element $element)
+    {
+        $words = array();
+        foreach ($element->getChildren() as $child) {
+            $node = $child->accept($this);
+            if ($node instanceof AST\TextNode) {
+                $words[] = $node->getText();
+            } else {
+                throw new \Exception('Term node can only contain text nodes');
+            }
+        }
+
+        return new AST\TermNode(implode(' ', $words));
     }
 
     private function visitText(Element $element)

--- a/lib/Alchemy/Phrasea/SearchEngine/Elastic/Thesaurus/Term.php
+++ b/lib/Alchemy/Phrasea/SearchEngine/Elastic/Thesaurus/Term.php
@@ -11,8 +11,6 @@
 
 namespace Alchemy\Phrasea\SearchEngine\Elastic\Thesaurus;
 
-use Alchemy\Phrasea\SearchEngine\Elastic\AST\TextNode;
-
 class Term implements TermInterface
 {
     private $value;
@@ -49,9 +47,9 @@ class Term implements TermInterface
     public static function dump(TermInterface $term)
     {
         if ($term->hasContext()) {
-            return sprintf('%s (%s)', $term->getValue(), $term->getContext());
+            return sprintf('"%s" context:"%s"', $term->getValue(), $term->getContext());
         }
 
-        return $term->getValue();
+        return sprintf('"%s"', $term->getValue());
     }
 }

--- a/www/skins/prod/jquery.main-prod.js
+++ b/www/skins/prod/jquery.main-prod.js
@@ -469,10 +469,7 @@ function initAnswerForm() {
                     query = JSON.parse(query);
                 }
                 catch (e) {}
-
-                console.info('All Details:', query);
-                console.debug('Paths:');
-                console.debug(query._paths);
+                console.info(query);
 
                 var aggs = datas.aggregations;
                 try {


### PR DESCRIPTION
For now it's only about parser support of the following search forms:
- `chien IN Keyword` : looks for full text `chien`, synonyms, translations, but only in the `Keyword` field
- `"chien" IN Keyword` : looks for full text `chien` in `Keyword` field
- `[chien] IN Keyword` : looks for the dog concept, his synonyms, translations and specific terms in the `Keyword`field
- `[chien]` : only looks for the dog concept, synonyms, translations and more specific terms
